### PR TITLE
fix: ensure we can serialize/deserialize the ghsa model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 2.0.2 - 2023-02-22
+
+### Fixed
+
+- Ensure GHSA model can be serialized and deserialized ([#35](https://github.com/jeremylong/vuln-tools/pull/35)).
+
 ## 2.0.1 - 2023-02-21
 
 ### Fixed

--- a/buildSrc/src/main/groovy/vuln.tools.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/vuln.tools.java-common-conventions.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group 'io.github.jeremylong'
-version = '2.0.1'
+version = '2.0.2'
 
 repositories {
     mavenCentral()

--- a/gh-advisory-lib/README.md
+++ b/gh-advisory-lib/README.md
@@ -12,14 +12,14 @@ The client requires a GitHub Personal Access Token to access the API.
 <dependency>
    <groupId>io.github.jeremylong</groupId>
    <artifactId>gh-advisory-lib</artifactId>
-   <version>2.0.1</version>
+   <version>2.0.2</version>
 </dependency>
 ```
 
 ### gradle
 
 ```groovy
-implementation 'io.github.jeremylong:gh-advisory-lib:2.0.1'
+implementation 'io.github.jeremylong:gh-advisory-lib:2.0.2'
 ```
 
 ### building from source

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/CWE.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/CWE.java
@@ -17,6 +17,7 @@ package io.github.jeremylong.ghsa;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import java.util.Objects;
 
@@ -24,6 +25,7 @@ import java.util.Objects;
  * Common weakness enumeration.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonPropertyOrder({"cweId", "name", "description"})
 public class CWE {
 
     @JsonProperty(value = "node", access = JsonProperty.Access.WRITE_ONLY)
@@ -35,7 +37,17 @@ public class CWE {
      * @return the id of the CWE
      */
     public String getCweId() {
+        if (node == null) {
+            return null;
+        }
         return node.cweId;
+    }
+
+    void setCweId(String cweId) {
+        if (node == null) {
+            this.node = new CWERecord();
+        }
+        node.cweId = cweId;
     }
 
     /**
@@ -44,7 +56,17 @@ public class CWE {
      * @return a detailed description of this CWE.
      */
     public String getDescription() {
+        if (node == null) {
+            return null;
+        }
         return node.description;
+    }
+
+    void setDescription(String description) {
+        if (node == null) {
+            node = new CWERecord();
+        }
+        node.description = description;
     }
 
     /**
@@ -53,7 +75,17 @@ public class CWE {
      * @return the name of this CWE.
      */
     public String getName() {
+        if (node == null) {
+            return null;
+        }
         return node.name;
+    }
+
+    void setName(String name) {
+        if (node == null) {
+            node = new CWERecord();
+        }
+        node.name = name;
     }
 
     @Override

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/CWEs.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/CWEs.java
@@ -22,7 +22,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import java.util.Objects;
 
-public class CWEPage extends AbstractPageable {
+public class CWEs extends AbstractPageable {
 
     @JsonProperty("edges")
     private List<CWE> cwes;
@@ -30,13 +30,13 @@ public class CWEPage extends AbstractPageable {
     @SuppressFBWarnings(value = {"EI_EXPOSE_REP",
             "EI_EXPOSE_REP2"}, justification = "I prefer to suppress these FindBugs warnings")
     @JsonIgnore
-    public List<CWE> getPage() {
+    public List<CWE> getEdges() {
         return cwes;
     }
 
     @Override
     public String toString() {
-        return "CWEPage{" + "cwes=" + cwes + ", totalCount=" + getTotalCount() + "}";
+        return "CWEs{" + "cwes=" + cwes + ", totalCount=" + getTotalCount() + "}";
     }
 
     @Override
@@ -45,7 +45,7 @@ public class CWEPage extends AbstractPageable {
             return true;
         if (o == null || getClass() != o.getClass())
             return false;
-        CWEPage cwePage = (CWEPage) o;
+        CWEs cwePage = (CWEs) o;
         return Objects.equals(cwes, cwePage.cwes);
     }
 
@@ -54,7 +54,8 @@ public class CWEPage extends AbstractPageable {
         return Objects.hash(cwes);
     }
 
-    public boolean addCwes(List<CWE> c) {
+    boolean addCwes(List<CWE> c) {
         return this.cwes.addAll(c);
     }
+
 }

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/GitHubSecurityAdvisoryClient.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/GitHubSecurityAdvisoryClient.java
@@ -271,7 +271,7 @@ public class GitHubSecurityAdvisoryClient implements AutoCloseable, Iterator<Lis
                 if (body == null) {
                     body = new String(response.getBodyBytes(), StandardCharsets.UTF_8);
                 }
-                SecurityAdvisoriesResult results = objectMapper.readValue(body, SecurityAdvisoriesResult.class);
+                SecurityAdvisories results = objectMapper.readValue(body, SecurityAdvisories.class);
                 List<SecurityAdvisory> list = results.getSecurityAdvisories();
                 totalCount += list.size();
                 if (results.getPageInfo().isHasNextPage() || totalCount < results.getTotalCount()) {
@@ -343,12 +343,12 @@ public class GitHubSecurityAdvisoryClient implements AutoCloseable, Iterator<Lis
                 int max = sa.getCwes().getTotalCount();
                 String after = sa.getCwes().getPageInfo().getEndCursor();
                 while (count < max) {
-                    SecurityAdvisoryResult results = fetch(cwesTemplate, sa.getGhsaId(), after);
-                    CWEPage cwes = results.getSecurityAdvisory().getCwes();
-                    count += cwes.getPage().size();
+                    SecurityAdvisoryResponse results = fetch(cwesTemplate, sa.getGhsaId(), after);
+                    CWEs cwes = results.getSecurityAdvisory().getCwes();
+                    count += cwes.getEdges().size();
                     max = cwes.getTotalCount();
                     after = cwes.getPageInfo().getEndCursor();
-                    sa.getCwes().addCwes(cwes.getPage());
+                    sa.getCwes().addCwes(cwes.getEdges());
                 }
             }
             if (sa.getVulnerabilities().getPageInfo().isHasNextPage()
@@ -358,12 +358,12 @@ public class GitHubSecurityAdvisoryClient implements AutoCloseable, Iterator<Lis
                 int max = sa.getVulnerabilities().getTotalCount();
                 String after = sa.getVulnerabilities().getPageInfo().getEndCursor();
                 while (count < max) {
-                    SecurityAdvisoryResult results = fetch(vulnerabilitiesTemplate, sa.getGhsaId(), after);
-                    VulnerabilityPage vulnerability = results.getSecurityAdvisory().getVulnerabilities();
-                    count += vulnerability.getPage().size();
+                    SecurityAdvisoryResponse results = fetch(vulnerabilitiesTemplate, sa.getGhsaId(), after);
+                    Vulnerabilities vulnerability = results.getSecurityAdvisory().getVulnerabilities();
+                    count += vulnerability.getEdges().size();
                     max = vulnerability.getTotalCount();
                     after = vulnerability.getPageInfo().getEndCursor();
-                    sa.getVulnerabilities().addVulnerabilties(vulnerability.getPage());
+                    sa.getVulnerabilities().addVulnerabilties(vulnerability.getEdges());
                 }
             }
         }
@@ -379,9 +379,9 @@ public class GitHubSecurityAdvisoryClient implements AutoCloseable, Iterator<Lis
      * @throws ExecutionException thrown if there is a problem.
      * @throws InterruptedException thrown if interrupted.
      */
-    private SecurityAdvisoryResult fetch(Template template, String ghsaId, String after)
+    private SecurityAdvisoryResponse fetch(Template template, String ghsaId, String after)
             throws InterruptedException, ExecutionException {
-        SecurityAdvisoryResult results = null;
+        SecurityAdvisoryResponse results = null;
         try {
             Map<String, String> data = new HashMap<String, String>();
             data.put("ghsaId", ghsaId);
@@ -392,7 +392,7 @@ public class GitHubSecurityAdvisoryClient implements AutoCloseable, Iterator<Lis
             if (body == null) {
                 body = new String(response.getBodyBytes(), StandardCharsets.UTF_8);
             }
-            results = objectMapper.readValue(body, SecurityAdvisoryResult.class);
+            results = objectMapper.readValue(body, SecurityAdvisoryResponse.class);
         } catch (JsonProcessingException e) {
             LOG.debug("Deserialization Error", e);
             throw new GitHubSecurityAdvisoryException(e);

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/Identifier.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/Identifier.java
@@ -17,17 +17,19 @@ package io.github.jeremylong.ghsa;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import java.util.Objects;
 
 /**
  * A GitHub Security Advisory Identifier.
- * 
+ *
  * <pre>
  * type SecurityAdvisoryIdentifier
  * </pre>
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonPropertyOrder({"type", "value"})
 public class Identifier {
 
     @JsonProperty("type")

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/Package.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/Package.java
@@ -17,6 +17,7 @@ package io.github.jeremylong.ghsa;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import java.util.Objects;
 
@@ -28,7 +29,8 @@ import java.util.Objects;
  * </pre>
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-class Package {
+@JsonPropertyOrder({"ecosystem", "name"})
+public class Package {
 
     @JsonProperty("ecosystem")
     private String ecosystem;

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/SecurityAdvisories.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/SecurityAdvisories.java
@@ -15,6 +15,7 @@
  */
 package io.github.jeremylong.ghsa;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -22,9 +23,9 @@ import java.util.List;
 import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class SecurityAdvisoriesResult {
+public class SecurityAdvisories {
 
-    @JsonProperty("data")
+    @JsonProperty(value = "data", access = JsonProperty.Access.WRITE_ONLY)
     private Data data;
 
     /**
@@ -32,7 +33,11 @@ public class SecurityAdvisoriesResult {
      *
      * @return the rate limit.
      */
-    public RateLimit getRateLimit() {
+    @JsonIgnore
+    RateLimit getRateLimit() {
+        if (data == null) {
+            return null;
+        }
         return data.rateLimit;
     }
 
@@ -42,7 +47,18 @@ public class SecurityAdvisoriesResult {
      * @return the security advisories.
      */
     public List<SecurityAdvisory> getSecurityAdvisories() {
+        if (data == null || data.securityAdvisories == null) {
+            return null;
+        }
         return data.securityAdvisories.nodes;
+    }
+
+    void setSecurityAdvisories(List<SecurityAdvisory> advisories) {
+        if (data == null) {
+            data = new Data();
+            data.securityAdvisories = new Advisories();
+        }
+        data.securityAdvisories.nodes = advisories;
     }
 
     /**
@@ -50,7 +66,11 @@ public class SecurityAdvisoriesResult {
      *
      * @return the page info.
      */
-    public PageInfo getPageInfo() {
+    @JsonIgnore
+    PageInfo getPageInfo() {
+        if (data == null || data.securityAdvisories == null) {
+            return null;
+        }
         return data.securityAdvisories.getPageInfo();
     }
 
@@ -59,7 +79,11 @@ public class SecurityAdvisoriesResult {
      *
      * @return the total count.
      */
+    @JsonIgnore
     public int getTotalCount() {
+        if (data == null || data.securityAdvisories == null) {
+            return 0;
+        }
         return data.securityAdvisories.getTotalCount();
     }
 
@@ -77,7 +101,7 @@ public class SecurityAdvisoriesResult {
             return true;
         if (o == null || getClass() != o.getClass())
             return false;
-        SecurityAdvisoriesResult that = (SecurityAdvisoriesResult) o;
+        SecurityAdvisories that = (SecurityAdvisories) o;
         return Objects.equals(data, that.data);
     }
 
@@ -94,7 +118,7 @@ public class SecurityAdvisoriesResult {
         @JsonProperty("rateLimit")
         private RateLimit rateLimit;
         @JsonProperty("securityAdvisories")
-        private SecurityAdvisories securityAdvisories;
+        private Advisories securityAdvisories;
 
         @Override
         public String toString() {
@@ -122,7 +146,7 @@ public class SecurityAdvisoriesResult {
      * internal security advisories.
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
-    static class SecurityAdvisories extends AbstractPageable {
+    static class Advisories extends AbstractPageable {
 
         @JsonProperty("nodes")
         private List<SecurityAdvisory> nodes;
@@ -138,7 +162,7 @@ public class SecurityAdvisoriesResult {
                 return true;
             if (o == null || getClass() != o.getClass())
                 return false;
-            SecurityAdvisories that = (SecurityAdvisories) o;
+            Advisories that = (Advisories) o;
             return Objects.equals(nodes, that.nodes);
         }
 

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/SecurityAdvisory.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/SecurityAdvisory.java
@@ -16,9 +16,9 @@
 package io.github.jeremylong.ghsa;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.time.ZonedDateTime;
@@ -26,6 +26,9 @@ import java.util.List;
 import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonPropertyOrder({"databaseId", "description", "ghsaId", "id", "identifiers", "notificationsPermalink", "origin",
+        "permalink", "publishedAt", "references", "severity", "summary", "updatedAt", "vulnerabilities", "cvss", "cwes",
+        "withdrawnAt"})
 public class SecurityAdvisory {
 
     @JsonProperty("databaseId")
@@ -77,10 +80,10 @@ public class SecurityAdvisory {
     private CVSS cvss;
 
     @JsonProperty(value = "cwes")
-    private CWEPage cwes;
+    private CWEs cwes;
 
     @JsonProperty(value = "vulnerabilities")
-    private VulnerabilityPage vulnerabilities;
+    private Vulnerabilities vulnerabilities;
 
     /**
      * Identifies the primary key from the database.
@@ -222,13 +225,13 @@ public class SecurityAdvisory {
     }
 
     /**
-     * Returns CWEs associated with this Advisory.
+     * Returns CWE Page associated with this Advisory.
      *
      * @return CWEs associated with this Advisory.
      */
     @SuppressFBWarnings(value = {"EI_EXPOSE_REP",
             "EI_EXPOSE_REP2"}, justification = "I prefer to suppress these FindBugs warnings")
-    public CWEPage getCwes() {
+    public CWEs getCwes() {
         return cwes;
     }
 
@@ -239,7 +242,7 @@ public class SecurityAdvisory {
      */
     @SuppressFBWarnings(value = {"EI_EXPOSE_REP",
             "EI_EXPOSE_REP2"}, justification = "I prefer to suppress these FindBugs warnings")
-    public VulnerabilityPage getVulnerabilities() {
+    public Vulnerabilities getVulnerabilities() {
         return vulnerabilities;
     }
 

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/SecurityAdvisoryResponse.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/SecurityAdvisoryResponse.java
@@ -21,8 +21,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import java.util.Objects;
 
+/**
+ * Internal class used to gather additional vulnerabilities if a security advisory has more than 100 entries.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class SecurityAdvisoryResult {
+class SecurityAdvisoryResponse {
 
     @JsonProperty("data")
     private Data data;
@@ -59,7 +62,7 @@ public class SecurityAdvisoryResult {
             return true;
         if (o == null || getClass() != o.getClass())
             return false;
-        SecurityAdvisoryResult that = (SecurityAdvisoryResult) o;
+        SecurityAdvisoryResponse that = (SecurityAdvisoryResponse) o;
         return Objects.equals(data, that.data);
     }
 
@@ -116,8 +119,7 @@ public class SecurityAdvisoryResult {
 
         @Override
         public String toString() {
-            return "SecurityAdvisories{" + "nodes=" + nodes + ", totalCount=" + totalCount + ", pageInfo=" + pageInfo
-                    + '}';
+            return "Advisories{" + "nodes=" + nodes + ", totalCount=" + totalCount + ", pageInfo=" + pageInfo + '}';
         }
 
         @Override

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/Vulnerabilities.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/Vulnerabilities.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class VulnerabilityPage extends AbstractPageable {
+public class Vulnerabilities extends AbstractPageable {
 
     @JsonProperty("edges")
     private List<Vulnerability> vulnerabilities;
@@ -32,17 +32,17 @@ public class VulnerabilityPage extends AbstractPageable {
     @SuppressFBWarnings(value = {"EI_EXPOSE_REP",
             "EI_EXPOSE_REP2"}, justification = "I prefer to suppress these FindBugs warnings")
     @JsonIgnore
-    public List<Vulnerability> getPage() {
+    public List<Vulnerability> getEdges() {
         return vulnerabilities;
     }
 
-    public boolean addVulnerabilties(List<Vulnerability> v) {
+    boolean addVulnerabilties(List<Vulnerability> v) {
         return vulnerabilities.addAll(v);
     }
 
     @Override
     public String toString() {
-        return "VulnerabilityPage{" + "vulnerabilities=" + vulnerabilities + '}';
+        return "Vulnerabilities{" + "vulnerabilities=" + vulnerabilities + '}';
     }
 
     @Override
@@ -51,7 +51,7 @@ public class VulnerabilityPage extends AbstractPageable {
             return true;
         if (o == null || getClass() != o.getClass())
             return false;
-        VulnerabilityPage that = (VulnerabilityPage) o;
+        Vulnerabilities that = (Vulnerabilities) o;
         return Objects.equals(vulnerabilities, that.vulnerabilities);
     }
 
@@ -59,4 +59,5 @@ public class VulnerabilityPage extends AbstractPageable {
     public int hashCode() {
         return Objects.hash(vulnerabilities);
     }
+
 }

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/Vulnerability.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/Vulnerability.java
@@ -17,6 +17,7 @@ package io.github.jeremylong.ghsa;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import java.time.ZonedDateTime;
 import java.util.Objects;
@@ -29,6 +30,7 @@ import java.util.Objects;
  * </pre>
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonPropertyOrder({"severity", "updatedAt", "firstPatchedVersion", "vulnerableVersionRange", "package"})
 public class Vulnerability {
 
     @JsonProperty(value = "node", access = JsonProperty.Access.WRITE_ONLY)
@@ -39,8 +41,25 @@ public class Vulnerability {
      *
      * @return the first version containing a fix for the vulnerability.
      */
+    @JsonProperty(value = "firstPatchedVersion")
     public PackageVersion getFirstPatchedVersion() {
+        if (node == null) {
+            return null;
+        }
         return node.firstPatchedVersion;
+    }
+
+    /**
+     * Internal setter for deserialization.
+     *
+     * @param packageVersion the version.
+     */
+    @JsonProperty(value = "firstPatchedVersion")
+    void setFirstPatchedVersion(PackageVersion packageVersion) {
+        if (node == null) {
+            node = new VulnerabilityRecord();
+        }
+        node.firstPatchedVersion = packageVersion;
     }
 
     /**
@@ -48,8 +67,25 @@ public class Vulnerability {
      *
      * @return a description of the vulnerable package.
      */
+    @JsonProperty(value = "package")
     public Package getPackage() {
+        if (node == null) {
+            return null;
+        }
         return node.pkg;
+    }
+
+    /**
+     * Internal setter for deserialization.
+     *
+     * @param pkg the package
+     */
+    @JsonProperty(value = "package")
+    void setPackage(Package pkg) {
+        if (node == null) {
+            node = new VulnerabilityRecord();
+        }
+        node.pkg = pkg;
     }
 
     /**
@@ -57,8 +93,25 @@ public class Vulnerability {
      *
      * @return the severity of the vulnerability within this package.
      */
+    @JsonProperty(value = "severity")
     public Severity getSeverity() {
+        if (node == null) {
+            return null;
+        }
         return node.severity;
+    }
+
+    /**
+     * Internal setter for deserialization.
+     *
+     * @param severity severity
+     */
+    @JsonProperty(value = "severity")
+    void setSeverity(Severity severity) {
+        if (node == null) {
+            node = new VulnerabilityRecord();
+        }
+        node.severity = severity;
     }
 
     /**
@@ -66,8 +119,25 @@ public class Vulnerability {
      *
      * @return when the vulnerability was last updated.
      */
+    @JsonProperty(value = "updatedAt")
     public ZonedDateTime getUpdatedAt() {
+        if (node == null) {
+            return null;
+        }
         return node.updatedAt;
+    }
+
+    /**
+     * Internal setter for deserialization.
+     *
+     * @param updatedAt updated date time
+     */
+    @JsonProperty(value = "updatedAt")
+    void setUpdatedAt(ZonedDateTime updatedAt) {
+        if (node == null) {
+            node = new VulnerabilityRecord();
+        }
+        node.updatedAt = updatedAt;
     }
 
     /**
@@ -83,8 +153,25 @@ public class Vulnerability {
      *
      * @return the range.
      */
+    @JsonProperty(value = "vulnerableVersionRange")
     public String getVulnerableVersionRange() {
+        if (node == null) {
+            return null;
+        }
         return node.vulnerableVersionRange;
+    }
+
+    /**
+     * Internal setter for deserialization.
+     *
+     * @param range the range
+     */
+    @JsonProperty(value = "vulnerableVersionRange")
+    void setVulnerableVersionRange(String range) {
+        if (node == null) {
+            node = new VulnerabilityRecord();
+        }
+        node.vulnerableVersionRange = range;
     }
 
     @Override

--- a/gh-advisory-lib/src/test/java/io/github/jeremylong/ghsa/SerializationTest.java
+++ b/gh-advisory-lib/src/test/java/io/github/jeremylong/ghsa/SerializationTest.java
@@ -15,44 +15,40 @@
  */
 package io.github.jeremylong.ghsa;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import io.github.jeremylong.ghsa.SecurityAdvisoriesResult;
 import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SerializationTest {
 
     @Test
-    void parse() throws IOException {
+    void thereAndBackAgain() throws IOException {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        objectMapper.enable(SerializationFeature.WRITE_DATES_WITH_ZONE_ID);
-        objectMapper.disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
-        objectMapper.setTimeZone(TimeZone.getTimeZone("UTC"));
 
         String json;
         try (BufferedReader r = new BufferedReader(new InputStreamReader(
                 this.getClass().getClassLoader().getResourceAsStream("advisories.json"), StandardCharsets.UTF_8))) {
             json = r.lines().collect(Collectors.joining("\n"));
         }
-        SecurityAdvisoriesResult current = objectMapper.readValue(json, SecurityAdvisoriesResult.class);
+        SecurityAdvisories current = objectMapper.readValue(json, SecurityAdvisories.class);
         assertEquals(5000, current.getRateLimit().getLimit());
 
-        // File f = File.createTempFile("ghsa","json");
-        // objectMapper.
+        String serialized = objectMapper.writeValueAsString(current);
+        SecurityAdvisories hydrated = objectMapper.readValue(serialized, SecurityAdvisories.class);
+        String reserialized = objectMapper.writeValueAsString(hydrated);
+        assertTrue(serialized.equals(reserialized));
 
     }
 }

--- a/nvd-lib/README.md
+++ b/nvd-lib/README.md
@@ -14,14 +14,14 @@ Vulnerability Catalog can be downloaded in ~90 seconds.
 <dependency>
    <groupId>io.github.jeremylong</groupId>
    <artifactId>nvd-lib</artifactId>
-   <version>2.0.1</version>
+   <version>2.0.2</version>
 </dependency>
 ```
 
 ### gradle
 
 ```groovy
-implementation 'io.github.jeremylong:nvd-lib:2.0.1'
+implementation 'io.github.jeremylong:nvd-lib:2.0.2'
 ```
 
 ### building from source


### PR DESCRIPTION
- ensure we can serialize and deserialize the ghsa model
- correct type names and visibility
- fix possible NPE

I'm still not happy with having the `edge` nodes in the serialization - but it is the only way I can figure out how to have a single model that can deserialize the response from GitHub's GraphQL endpoint and serialize/deserialize a slightly condensed schema.