### PR TITLE
chore: update license header

### DIFF
--- a/buildSrc/src/main/config/java.license
+++ b/buildSrc/src/main/config/java.license
@@ -1,6 +1,4 @@
 /*
- *  Copyright $today.year Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,4 +10,7 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) $today.year Jeremy Long. All Rights Reserved.
  */

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/AbstractPageable.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/AbstractPageable.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.ghsa;
 

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/CVSS.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/CVSS.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.ghsa;
 

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/CWE.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/CWE.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.ghsa;
 

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/CWEs.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/CWEs.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.ghsa;
 

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/GitHubSecurityAdvisoryClient.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/GitHubSecurityAdvisoryClient.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.ghsa;
 

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/GitHubSecurityAdvisoryClientBuilder.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/GitHubSecurityAdvisoryClientBuilder.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2022-2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2022-2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.ghsa;
 

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/GitHubSecurityAdvisoryException.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/GitHubSecurityAdvisoryException.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2022-2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2022-2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.ghsa;
 

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/Identifier.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/Identifier.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.ghsa;
 

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/Package.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/Package.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.ghsa;
 

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/PackageVersion.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/PackageVersion.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.ghsa;
 

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/PageInfo.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/PageInfo.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.ghsa;
 

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/RateLimit.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/RateLimit.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.ghsa;
 

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/Reference.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/Reference.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.ghsa;
 

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/SecurityAdvisories.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/SecurityAdvisories.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.ghsa;
 

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/SecurityAdvisory.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/SecurityAdvisory.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.ghsa;
 

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/SecurityAdvisoryResponse.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/SecurityAdvisoryResponse.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.ghsa;
 

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/Severity.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/Severity.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.ghsa;
 

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/SimpleFutureResponse.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/SimpleFutureResponse.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.ghsa;
 

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/Vulnerabilities.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/Vulnerabilities.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.ghsa;
 

--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/Vulnerability.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/Vulnerability.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.ghsa;
 

--- a/gh-advisory-lib/src/test/java/io/github/jeremylong/ghsa/GitHubSecurityAdvisoryClientTest.java
+++ b/gh-advisory-lib/src/test/java/io/github/jeremylong/ghsa/GitHubSecurityAdvisoryClientTest.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.ghsa;
 

--- a/gh-advisory-lib/src/test/java/io/github/jeremylong/ghsa/SerializationTest.java
+++ b/gh-advisory-lib/src/test/java/io/github/jeremylong/ghsa/SerializationTest.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.ghsa;
 

--- a/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/NvdApiException.java
+++ b/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/NvdApiException.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2022-2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2022-2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.nvdlib;
 

--- a/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/NvdCveApi.java
+++ b/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/NvdCveApi.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2022-2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2022-2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.nvdlib;
 

--- a/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/NvdCveApiBuilder.java
+++ b/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/NvdCveApiBuilder.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2022-2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2022-2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.nvdlib;
 

--- a/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/RateLimitedClient.java
+++ b/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/RateLimitedClient.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2022-2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2022-2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.nvdlib;
 

--- a/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/RateMeter.java
+++ b/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/RateMeter.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2022-2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2022-2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.nvdlib;
 

--- a/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/Config.java
+++ b/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/Config.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.nvdlib.nvd;
 

--- a/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/CpeMatch.java
+++ b/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/CpeMatch.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.nvdlib.nvd;
 

--- a/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/CveApiJson20.java
+++ b/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/CveApiJson20.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.nvdlib.nvd;
 

--- a/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/CveItem.java
+++ b/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/CveItem.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.nvdlib.nvd;
 

--- a/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/CvssV2.java
+++ b/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/CvssV2.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.nvdlib.nvd;
 

--- a/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/CvssV20.java
+++ b/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/CvssV20.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.nvdlib.nvd;
 

--- a/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/CvssV30.java
+++ b/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/CvssV30.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.nvdlib.nvd;
 

--- a/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/CvssV30Data.java
+++ b/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/CvssV30Data.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.nvdlib.nvd;
 

--- a/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/CvssV31.java
+++ b/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/CvssV31.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.nvdlib.nvd;
 

--- a/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/CvssV31Data.java
+++ b/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/CvssV31Data.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.nvdlib.nvd;
 

--- a/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/DefCveItem.java
+++ b/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/DefCveItem.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.nvdlib.nvd;
 

--- a/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/LangString.java
+++ b/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/LangString.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.nvdlib.nvd;
 

--- a/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/Metrics.java
+++ b/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/Metrics.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.nvdlib.nvd;
 

--- a/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/Node.java
+++ b/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/Node.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.nvdlib.nvd;
 

--- a/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/Reference.java
+++ b/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/Reference.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.nvdlib.nvd;
 

--- a/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/VendorComment.java
+++ b/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/VendorComment.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.nvdlib.nvd;
 
@@ -41,7 +42,8 @@ public class VendorComment {
      * (Required)
      */
     @JsonProperty("lastModified")
-    //the below format is a hack work around due to some poorly formated dates in the NVD data, the getter corrects the serizlized format
+    // the below format is a hack work around due to some poorly formated dates in the NVD data, the getter corrects the
+    // serizlized format
     @JsonFormat(pattern = "uuuu-MM-dd'T'HH:mm:ss[.[SSSSSSSSS][SSSSSSSS][SSSSSSS][SSSSSS][SSSSS][SSSS][SSS][SS][S]]", timezone = "UTC")
     private ZonedDateTime lastModified;
 

--- a/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/Weakness.java
+++ b/nvd-lib/src/main/java/io/github/jeremylong/nvdlib/nvd/Weakness.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.nvdlib.nvd;
 

--- a/nvd-lib/src/test/java/io/github/jeremylong/nvdlib/NvdCveApiTest.java
+++ b/nvd-lib/src/test/java/io/github/jeremylong/nvdlib/NvdCveApiTest.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2022-2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2022-2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.nvdlib;
 

--- a/nvd-lib/src/test/java/io/github/jeremylong/nvdlib/RateMeterTest.java
+++ b/nvd-lib/src/test/java/io/github/jeremylong/nvdlib/RateMeterTest.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2022-2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2022-2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.nvdlib;
 

--- a/nvd-lib/src/test/java/io/github/jeremylong/nvdlib/nvd/SerializationTest.java
+++ b/nvd-lib/src/test/java/io/github/jeremylong/nvdlib/nvd/SerializationTest.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2022-2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2022-2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.nvdlib.nvd;
 

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/Application.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/Application.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2022-2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2022-2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.vulnz.cli;
 

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/AbstractHelpfulCommand.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/AbstractHelpfulCommand.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2022-2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2022-2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.vulnz.cli.commands;
 

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/AbstractJsonCommand.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/AbstractJsonCommand.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2022-2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2022-2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.vulnz.cli.commands;
 

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/AbstractNvdCommand.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/AbstractNvdCommand.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2022-2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2022-2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.vulnz.cli.commands;
 

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/CveCommand.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/CveCommand.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2022-2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2022-2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.vulnz.cli.commands;
 

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/GHSACommand.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/GHSACommand.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2022-2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2022-2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.vulnz.cli.commands;
 

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/InstallCommand.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/InstallCommand.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2022-2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2022-2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.vulnz.cli.commands;
 

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/MainCommand.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/MainCommand.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2022-2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2022-2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.vulnz.cli.commands;
 

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/TimedCommand.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/commands/TimedCommand.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2022-2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2022-2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.vulnz.cli.commands;
 

--- a/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/model/BasicOutput.java
+++ b/vulnz/src/main/java/io/github/jeremylong/vulnz/cli/model/BasicOutput.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2022-2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2022-2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.vulnz.cli.model;
 

--- a/vulnz/src/test/java/io/github/jeremylong/vulnz/cli/NvdApplicationTests.java
+++ b/vulnz/src/test/java/io/github/jeremylong/vulnz/cli/NvdApplicationTests.java
@@ -1,6 +1,4 @@
 /*
- *  Copyright 2022-2023 Jeremy Long
- *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -12,6 +10,9 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2022-2023 Jeremy Long. All Rights Reserved.
  */
 package io.github.jeremylong.vulnz.cli;
 


### PR DESCRIPTION
no change in license, just adding the `SPDX-License-Identifier: Apache-2.0`.