### PR TITLE
Pass custom `endpoint` to `GitHubSecurityAdvisoryClient` when set

### DIFF
--- a/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/GitHubSecurityAdvisoryClientBuilder.java
+++ b/gh-advisory-lib/src/main/java/io/github/jeremylong/ghsa/GitHubSecurityAdvisoryClientBuilder.java
@@ -20,9 +20,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.ZonedDateTime;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 
 /**
  * Used to build an GitHub SecurityAdvisory GraphQL API client. As the GitHubSecurityAdvisoryClient client is
@@ -125,7 +122,12 @@ public final class GitHubSecurityAdvisoryClientBuilder {
      * @return the GitHub SecurityAdvisory GraphQL API client
      */
     public GitHubSecurityAdvisoryClient build() {
-        GitHubSecurityAdvisoryClient client = new GitHubSecurityAdvisoryClient(apiKey);
+        GitHubSecurityAdvisoryClient client;
+        if (endpoint == null) {
+            client = new GitHubSecurityAdvisoryClient(apiKey);
+        }  else {
+            client = new GitHubSecurityAdvisoryClient(apiKey, endpoint);
+        }
         if (publishedSince != null) {
             client.setPublishedSinceFilter(publishedSince);
         }


### PR DESCRIPTION
Custom endpoints set via `GitHubSecurityAdvisoryClientBuilder#withEndpoint` when building the GitHub client did not take effect, as they were not passed to the client instance when calling `build()` on the builder.